### PR TITLE
Add Sled entity to en_us and it_it langs

### DIFF
--- a/src/main/resources/assets/snowyspirit/lang/en_us.json
+++ b/src/main/resources/assets/snowyspirit/lang/en_us.json
@@ -32,6 +32,7 @@
   "block.snowyspirit.gumdrop_gray": "Gray Gumdrop",
   "block.snowyspirit.gumdrop_black": "Black Gumdrop",
   "block.snowyspirit.gumdrop_brown": "Brown Gumdrop",
+  "entity.snowyspirit.sled": "Sled",
   "entity.snowyspirit.container_entity": "Sled Chest",
   "message.snowyspirit.container_entity_name": "Sled %s",
   "block.snowyspirit.glow_lights_red": "Red Glow Lights",

--- a/src/main/resources/assets/snowyspirit/lang/it_it.json
+++ b/src/main/resources/assets/snowyspirit/lang/it_it.json
@@ -32,6 +32,7 @@
   "block.snowyspirit.gumdrop_gray": "Caramella gommosa grigia",
   "block.snowyspirit.gumdrop_black": "Caramella gommosa nera",
   "block.snowyspirit.gumdrop_brown": "Caramella gommosa marrone",
+  "entity.snowyspirit.sled": "Slitta",
   "entity.snowyspirit.container_entity": "Slitta con baule",
   "message.snowyspirit.container_entity_name": "Slitta %s",
   "block.snowyspirit.glow_lights_red": "Luci natalizie rosse",


### PR DESCRIPTION
When you look at a Sled entity with Jade, it shows you the entity's id instead of the name. For this reason I added the Sled entity to the lang.