### PR TITLE
Fix incorrect dye tag in recipe for Light Blue Glow Lights.

### DIFF
--- a/src/main/resources/data/snowyspirit/recipes/glow_lights_light_blue.json
+++ b/src/main/resources/data/snowyspirit/recipes/glow_lights_light_blue.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {"item": "minecraft:glowstone_dust"},
-    {"tag": "forge:dyes/cyan"},
+    {"tag": "forge:dyes/light_blue"},
     {"tag": "forge:string"}
   ],
   "result": {


### PR DESCRIPTION
Recipe for Light Blue Glow Lights was using "forge:dyes/cyan" and not "forge:dyes/light_blue".