### PR TITLE
Update moonlight lib to solve #113

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     if (isMyPc) {
         modImplementation("net.mehvahdjukaar:moonlight:${moonlight_version}")
     } else {
-        modImplementation("curse.maven:selene-499980:5882410")
+        modImplementation("curse.maven:selene-499980:7068423")
     }
 
     modCompileOnly("curse.maven:farmers-delight-398521:5772720")

--- a/common/src/main/java/net/mehvahdjukaar/snowyspirit/SnowySpirit.java
+++ b/common/src/main/java/net/mehvahdjukaar/snowyspirit/SnowySpirit.java
@@ -55,7 +55,7 @@ public class SnowySpirit {
 
         CommonConfigs.init();
 
-        ServerDynamicResourcesHandler.INSTANCE.register();
+        RegHelper.registerDynamicResourceProvider(ServerDynamicResourcesHandler.INSTANCE);
 
         ModNetworking.init();
 
@@ -73,7 +73,7 @@ public class SnowySpirit {
         if (PlatHelper.getPhysicalSide().isClient()) {
             ClientConfigs.init();
 
-            ClientDynamicResourcesHandler.INSTANCE.register();
+            RegHelper.registerDynamicResourceProvider(ClientDynamicResourcesHandler.INSTANCE);
 
             ClientRegistry.init();
             ClientHelper.addClientSetup(ClientRegistry::setup);

--- a/common/src/main/java/net/mehvahdjukaar/snowyspirit/client/SledEntityRenderer.java
+++ b/common/src/main/java/net/mehvahdjukaar/snowyspirit/client/SledEntityRenderer.java
@@ -47,7 +47,7 @@ public class SledEntityRenderer extends EntityRenderer<SledEntity> {
         this.model = new SledModel<>(context.bakeLayer(ClientRegistry.SLED_MODEL));
         this.modelBamboo = new SledModel<>(context.bakeLayer(ClientRegistry.SLED_MODEL_BAMBOO));
         this.quiltModel = new QuiltModel<>(context.bakeLayer(ClientRegistry.QUILT_MODEL));
-        this.textures = WoodTypeRegistry.getTypes().stream().collect(ImmutableMap.toImmutableMap((e) -> e,
+        this.textures = WoodTypeRegistry.INSTANCE.getValues().stream().collect(ImmutableMap.toImmutableMap((e) -> e,
                 (t) -> SnowySpirit.res("textures/entity/sled/" + t.getTexturePath() + ".png")));
         this.quiltTextures = Stream.of(DyeColor.values()).collect(ImmutableMap.toImmutableMap((e) -> e,
                 (t) -> SnowySpirit.res("textures/entity/sled/quilt/" + t.getName() + ".png")));
@@ -122,7 +122,7 @@ public class SledEntityRenderer extends EntityRenderer<SledEntity> {
         return this.textures.get(sled.getWoodType());
     }
 
-    public static final WoodType BAMBOO = WoodTypeRegistry.getValue(ResourceLocation.tryParse("bamboo"));
+    public static final WoodType BAMBOO = WoodTypeRegistry.INSTANCE.get(ResourceLocation.tryParse("bamboo"));
 
     public SledModel<SledEntity> getModel(SledEntity sled){
         return sled.getWoodType() == BAMBOO ? modelBamboo : model;

--- a/common/src/main/java/net/mehvahdjukaar/snowyspirit/common/entity/SledEntity.java
+++ b/common/src/main/java/net/mehvahdjukaar/snowyspirit/common/entity/SledEntity.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import net.mehvahdjukaar.moonlight.api.entity.IControllableVehicle;
 import net.mehvahdjukaar.moonlight.api.platform.network.NetworkHelper;
 import net.mehvahdjukaar.moonlight.api.set.BlocksColorAPI;
+import net.mehvahdjukaar.moonlight.api.set.wood.VanillaWoodTypes;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
 import net.mehvahdjukaar.moonlight.api.util.Utils;
@@ -151,7 +152,7 @@ public class SledEntity extends Entity implements IControllableVehicle {
 
     @Override
     protected void defineSynchedData(SynchedEntityData.Builder builder) {
-        builder.define(DATA_WOOD_TYPE, WoodTypeRegistry.OAK_TYPE);
+        builder.define(DATA_WOOD_TYPE, VanillaWoodTypes.OAK);
         builder.define(DATA_SEAT_TYPE, 0);
         builder.define(DATA_ID_HURT, 0);
         builder.define(DATA_ID_HURT_DIR, 1);

--- a/common/src/main/java/net/mehvahdjukaar/snowyspirit/dynamicpack/ClientDynamicResourcesHandler.java
+++ b/common/src/main/java/net/mehvahdjukaar/snowyspirit/dynamicpack/ClientDynamicResourcesHandler.java
@@ -1,13 +1,18 @@
 package net.mehvahdjukaar.snowyspirit.dynamicpack;
 
 import net.mehvahdjukaar.moonlight.api.events.AfterLanguageLoadEvent;
+import net.mehvahdjukaar.moonlight.api.misc.IProgressTracker;
 import net.mehvahdjukaar.moonlight.api.platform.PlatHelper;
 import net.mehvahdjukaar.moonlight.api.resources.RPUtils;
 import net.mehvahdjukaar.moonlight.api.resources.ResType;
 import net.mehvahdjukaar.moonlight.api.resources.StaticResource;
 import net.mehvahdjukaar.moonlight.api.resources.assets.LangBuilder;
 import net.mehvahdjukaar.moonlight.api.resources.pack.DynClientResourcesGenerator;
+import net.mehvahdjukaar.moonlight.api.resources.pack.DynamicClientResourceProvider;
 import net.mehvahdjukaar.moonlight.api.resources.pack.DynamicTexturePack;
+import net.mehvahdjukaar.moonlight.api.resources.pack.PackGenerationStrategy;
+import net.mehvahdjukaar.moonlight.api.resources.pack.ResourceGenTask;
+import net.mehvahdjukaar.moonlight.api.resources.pack.ResourceSink;
 import net.mehvahdjukaar.moonlight.api.resources.textures.Palette;
 import net.mehvahdjukaar.moonlight.api.resources.textures.Respriter;
 import net.mehvahdjukaar.moonlight.api.resources.textures.SpriteUtils;
@@ -23,20 +28,20 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
-public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
+public class ClientDynamicResourcesHandler extends DynamicClientResourceProvider {
 
     public static final ClientDynamicResourcesHandler INSTANCE = new ClientDynamicResourcesHandler();
 
     public ClientDynamicResourcesHandler() {
-        super(new DynamicTexturePack(SnowySpirit.res("generated_pack")));
-        this.dynamicPack.setGenerateDebugResources(PlatHelper.isDev() || CommonConfigs.DEBUG_RESOURCES.get());
+        super(SnowySpirit.res("generated_pack"), PackGenerationStrategy.CACHED);
     }
 
     private static final Map<DyeColor, float[]> COLORS = new EnumMap<>(DyeColor.class);
@@ -59,8 +64,8 @@ public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
     }
 
     @Override
-    protected void onNormalReload(ResourceManager manager) {
-        super.onNormalReload(manager);
+    public void reload(ResourceManager manager, IProgressTracker reporter) {
+        super.reload(manager, reporter);
 
         try {
             var l = SpriteUtils.parsePaletteStrip(manager,
@@ -88,26 +93,30 @@ public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
     }
 
     @Override
-    public Logger getLogger() {
-        return SnowySpirit.LOGGER;
+    protected Collection<String> gatherSupportedNamespaces() {
+        return List.of(SnowySpirit.MOD_ID);
     }
 
     @Override
-    public boolean dependsOnLoadedPacks() {
-        return true;
+    protected boolean generateDebugResources() {
+        return PlatHelper.isDev() || CommonConfigs.DEBUG_RESOURCES.get();
     }
 
     @Override
-    public void regenerateDynamicAssets(ResourceManager manager) {
+    protected void regenerateDynamicAssets(Consumer<ResourceGenTask> consumer) {
+        consumer.accept(this::regenerateDynamicAssets);
+    }
+
+    private void regenerateDynamicAssets(ResourceManager manager, ResourceSink sink) {
         StaticResource itemModel = StaticResource.getOrLog(manager,
                 ResType.ITEM_MODELS.getPath(SnowySpirit.res("sled_oak")));
 
         ModRegistry.SLED_ITEMS.forEach((wood, sled) -> {
 
             try {
-                this.addSimilarJsonResource(manager, itemModel, "sled_oak", wood.getVariantId("sled"));
+                sink.addSimilarJsonResource(manager, itemModel, "sled_oak", wood.getVariantId("sled"));
             } catch (Exception ex) {
-                getLogger().error("Failed to generate Sled item model for {} : {}", sled, ex);
+                SnowySpirit.LOGGER.error("Failed to generate Sled item model for {} : {}", sled, ex);
             }
         });
 
@@ -119,7 +128,7 @@ public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
             ModRegistry.SLED_ITEMS.forEach((wood, sled) -> {
 
                 ResourceLocation textureRes = SnowySpirit.res("entity/sled/" + wood.getTexturePath());
-                if (this.alreadyHasTextureAtLocation(manager, textureRes)) return;
+                if (sink.alreadyHasTextureAtLocation(manager, textureRes)) return;
 
 
                 try (TextureImage plankTexture = TextureImage.open(manager,
@@ -128,14 +137,14 @@ public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
                     var targetPalette = Palette.fromImage(plankTexture);
                     TextureImage newImage = respriter.recolor(targetPalette);
                     //TextureImage newImage = respriter.recolorWithAnimationOf(plankTexture);
-                    dynamicPack.addAndCloseTexture(textureRes, newImage, false);
+                    sink.addTexture(textureRes, newImage);
 
                 } catch (Exception ex) {
-                    getLogger().error("Failed to generate sled entity texture for for {} : {}", sled, ex);
+                    SnowySpirit.LOGGER.error("Failed to generate sled entity texture for for {} : {}", sled, ex);
                 }
             });
         } catch (Exception ex) {
-            getLogger().error("Could not generate any sled entity texture : ", ex);
+            SnowySpirit.LOGGER.error("Could not generate any sled entity texture : ", ex);
         }
 
         //item textures
@@ -149,7 +158,7 @@ public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
             ModRegistry.SLED_ITEMS.forEach((wood, sled) -> {
                 //if (wood.isVanilla()) continue;
                 ResourceLocation textureRes = SnowySpirit.res("item/sleds/" + Utils.getID(sled).getPath());
-                if (this.alreadyHasTextureAtLocation(manager, textureRes)) return;
+                if (sink.alreadyHasTextureAtLocation(manager, textureRes)) return;
 
                 TextureImage newImage = null;
                 Item boat = wood.getItemOfThis("boat");
@@ -161,7 +170,7 @@ public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
                         newImage = respriter.recolor(targetPalette);
 
                     } catch (Exception ex) {
-                        getLogger().warn("Could not find boat texture for wood type {}. Using plank texture : {}", wood, ex);
+                        SnowySpirit.LOGGER.warn("Could not find boat texture for wood type {}. Using plank texture : {}", wood, ex);
                     }
                 }
                 //if it failed use plank one
@@ -172,15 +181,15 @@ public class ClientDynamicResourcesHandler extends DynClientResourcesGenerator {
                         newImage = respriter.recolor(targetPalette);
 
                     } catch (Exception ex) {
-                        getLogger().error("Failed to generate sled item texture for for {} : {}", sled, ex);
+                        SnowySpirit.LOGGER.error("Failed to generate sled item texture for for {} : {}", sled, ex);
                     }
                 }
                 if (newImage != null) {
-                    dynamicPack.addAndCloseTexture(textureRes, newImage);
+                    sink.addTexture(textureRes, newImage);
                 }
             });
         } catch (Exception ex) {
-            getLogger().error("Could not generate any Sleds item texture : ", ex);
+            SnowySpirit.LOGGER.error("Could not generate any Sleds item texture : ", ex);
         }
     }
 

--- a/common/src/main/java/net/mehvahdjukaar/snowyspirit/dynamicpack/ServerDynamicResourcesHandler.java
+++ b/common/src/main/java/net/mehvahdjukaar/snowyspirit/dynamicpack/ServerDynamicResourcesHandler.java
@@ -3,9 +3,11 @@ package net.mehvahdjukaar.snowyspirit.dynamicpack;
 import net.mehvahdjukaar.moonlight.api.platform.PlatHelper;
 import net.mehvahdjukaar.moonlight.api.resources.RPUtils;
 import net.mehvahdjukaar.moonlight.api.resources.SimpleTagBuilder;
-import net.mehvahdjukaar.moonlight.api.resources.pack.DynServerResourcesGenerator;
-import net.mehvahdjukaar.moonlight.api.resources.pack.DynamicDataPack;
-import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
+import net.mehvahdjukaar.moonlight.api.resources.pack.DynamicServerResourceProvider;
+import net.mehvahdjukaar.moonlight.api.resources.pack.PackGenerationStrategy;
+import net.mehvahdjukaar.moonlight.api.resources.pack.ResourceGenTask;
+import net.mehvahdjukaar.moonlight.api.resources.pack.ResourceSink;
+import net.mehvahdjukaar.moonlight.api.set.wood.VanillaWoodTypes;
 import net.mehvahdjukaar.snowyspirit.SnowySpirit;
 import net.mehvahdjukaar.snowyspirit.configs.CommonConfigs;
 import net.mehvahdjukaar.snowyspirit.reg.ModRegistry;
@@ -13,52 +15,49 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.item.crafting.Recipe;
-import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
-public class ServerDynamicResourcesHandler extends DynServerResourcesGenerator {
+public class ServerDynamicResourcesHandler extends DynamicServerResourceProvider {
 
     public static final ServerDynamicResourcesHandler INSTANCE = new ServerDynamicResourcesHandler();
 
     public ServerDynamicResourcesHandler() {
-        super(new DynamicDataPack(SnowySpirit.res("generated_pack")));
-        this.dynamicPack.setGenerateDebugResources(PlatHelper.isDev() || CommonConfigs.DEBUG_RESOURCES.get());
+        super(SnowySpirit.res("generated_pack"), PackGenerationStrategy.CACHED);
     }
 
     @Override
-    public Collection<String> additionalNamespaces() {
-        return List.of("snowyspirit");
+    protected Collection<String> gatherSupportedNamespaces() {
+        return List.of(SnowySpirit.MOD_ID);
     }
 
     @Override
-    public Logger getLogger() {
-        return SnowySpirit.LOGGER;
+    protected void regenerateDynamicAssets(Consumer<ResourceGenTask> consumer) {
+        consumer.accept(this::regenerateDynamicAssets);
     }
 
-    @Override
-    public boolean dependsOnLoadedPacks() {
-        return true;
-    }
-
-    @Override
-    public void regenerateDynamicAssets(ResourceManager resourceManager) {
+    private void regenerateDynamicAssets(ResourceManager resourceManager, ResourceSink sink) {
 
         SimpleTagBuilder builder = SimpleTagBuilder.of(SnowySpirit.res("sleds"));
         builder.addEntries(ModRegistry.SLED_ITEMS.values());
-        dynamicPack.addTag(builder, Registries.ITEM);
+        sink.addTag(builder, Registries.ITEM);
 
         ResourceLocation id = SnowySpirit.res("sled_oak");
         Recipe<?> recipeTemplate = RPUtils.readRecipe(resourceManager, id);
 
         ModRegistry.SLED_ITEMS.forEach((w, b) -> {
-            if (w != WoodTypeRegistry.OAK_TYPE) {
-                var newR = RPUtils.makeSimilarRecipe(recipeTemplate, WoodTypeRegistry.OAK_TYPE, w, id);
-                this.dynamicPack.addRecipe(newR);
+            if (w != VanillaWoodTypes.OAK) {
+                var newR = RPUtils.makeSimilarRecipe(recipeTemplate, VanillaWoodTypes.OAK, w, id);
+                sink.addRecipe(newR);
             }
         });
     }
 
+    @Override
+    protected boolean generateDebugResources() {
+        return PlatHelper.isDev() || CommonConfigs.DEBUG_RESOURCES.get();
+    }
 
 }

--- a/common/src/main/java/net/mehvahdjukaar/snowyspirit/reg/ModCreativeTabs.java
+++ b/common/src/main/java/net/mehvahdjukaar/snowyspirit/reg/ModCreativeTabs.java
@@ -2,6 +2,7 @@ package net.mehvahdjukaar.snowyspirit.reg;
 
 import net.mehvahdjukaar.moonlight.api.misc.RegSupplier;
 import net.mehvahdjukaar.moonlight.api.platform.RegHelper;
+import net.mehvahdjukaar.moonlight.api.set.wood.VanillaWoodTypes;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
 import net.mehvahdjukaar.snowyspirit.SnowySpirit;
 import net.mehvahdjukaar.snowyspirit.configs.CommonConfigs;
@@ -24,7 +25,7 @@ public class ModCreativeTabs {
     public static final RegSupplier<CreativeModeTab> MOD_TAB = !CommonConfigs.MOD_TAB.get() ? null :
             RegHelper.registerCreativeModeTab(SnowySpirit.res(SnowySpirit.MOD_ID), builder ->
                     builder.title(Component.translatable("tab.snowyspirit")).icon(
-                            () -> ModRegistry.SLED_ITEMS.get(WoodTypeRegistry.OAK_TYPE).getDefaultInstance()));
+                            () -> ModRegistry.SLED_ITEMS.get(VanillaWoodTypes.OAK).getDefaultInstance()));
 
 
     public static void init() {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -31,7 +31,7 @@ dependencies {
         modImplementation("net.mehvahdjukaar:moonlight-fabric:${moonlight_version}")
         //modImplementation("curse.maven:selene-499980:5913547")
     } else {
-        modImplementation("curse.maven:selene-499980:5913547")
+        modImplementation("curse.maven:selene-499980:7068423")
     }
 
     modImplementation("curse.maven:yacl-667299:4574163")

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,15 +35,15 @@ parchment_version = 1.20.6:2024.06.16
 fabric_loader_version = 0.16.7
 fabric_api_version = 0.104.0+1.21.1
 
-neo_version = 21.1.49
+neo_version = 21.1.205
 neo_version_range = [4,)
 loader_version_range = [4,)
 
 # Other deps
 supplementaries_version = 1.21-3.0.26-beta
 
-moonlight_version = 1.21-2.17.11b
-moonlight_min_version = 1.21-2.17.7
+moonlight_version = 1.21-2.23.8b
+moonlight_min_version = 1.21-2.23.0
 
 
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -101,7 +101,7 @@ dependencies {
        // modCompileOnly("curse.maven:supplementaries-412082:5923343")
     //    modImplementation("net.mehvahdjukaar:supplementaries-neoforge:${supplementaries_version}")
     } else {
-        modImplementation("curse.maven:selene-499980:5878698")
+        modImplementation("curse.maven:selene-499980:7068422")
       //  modCompileOnly("curse.maven:supplementaries-412082:5923343")
     }
 

--- a/neoforge/src/main/java/net/mehvahdjukaar/snowyspirit/integration/configured/ModConfigScreen.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/snowyspirit/integration/configured/ModConfigScreen.java
@@ -5,6 +5,7 @@ import com.mrcrayfish.configured.api.IModConfig;
 import com.mrcrayfish.configured.client.util.ScreenUtil;
 import net.mehvahdjukaar.moonlight.api.integration.configured.CustomConfigScreen;
 import net.mehvahdjukaar.moonlight.api.integration.configured.CustomConfigSelectScreen;
+import net.mehvahdjukaar.moonlight.api.set.wood.VanillaWoodTypes;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
 import net.mehvahdjukaar.snowyspirit.SnowySpirit;
 import net.mehvahdjukaar.snowyspirit.reg.ModRegistry;
@@ -27,7 +28,7 @@ public class ModConfigScreen extends CustomConfigScreen {
     private static final Map<String, ItemStack> CUSTOM_ICONS = new HashMap<>();
 
     static {
-        addIcon("sleds", ModRegistry.SLED_ITEMS.get(WoodTypeRegistry.OAK_TYPE));
+        addIcon("sleds", ModRegistry.SLED_ITEMS.get(VanillaWoodTypes.OAK));
         addIcon("gumdrops", ModRegistry.GUMDROPS_BUTTONS.get(DyeColor.GREEN).get().asItem());
         addIcon("glow lights", ModRegistry.GLOW_LIGHTS_ITEMS.get(null).get().asItem());
         addIcon("blocks and items", ModRegistry.CANDY_CANE_BLOCK.get());


### PR DESCRIPTION
`DynClientResourcesGenerator` / `DynServerResourcesGenerator` are deprecated and no longer have the method `onNormalReload` in the newest versions, therefore this logic never get's triggered in snowy spirit.
I have migrated to the new resource providers & have also updated a few other deprecated fields in the process