### PR TITLE
Add some item tags to the translation strings

### DIFF
--- a/common/src/main/resources/assets/snowyspirit/lang/en_us.json
+++ b/common/src/main/resources/assets/snowyspirit/lang/en_us.json
@@ -91,5 +91,7 @@
   "message.snowyspirit.container_entity_name": "Sled %s",
   "subtitle.snowyspirit.music_disc.a_carol": "A Carol",
   "subtitle.snowyspirit.sled": "Sled sliding",
-  "tab.snowyspirit": "Snowy Spirit"
+  "tab.snowyspirit": "Snowy Spirit",
+  "tag.item.snowyspirit.gumdrops": "Gumdrops",
+  "tag.item.snowyspirit.sleds": "Sleds"
 }


### PR DESCRIPTION
Similar to https://github.com/MehVahdJukaar/Supplementaries/pull/1869, but I have no idea why the Github online editor decides to trim the last line this time.

_Should be fine to backport, too?__

